### PR TITLE
Add ability to advance dialogue with left click

### DIFF
--- a/godot/ScenePlayer.tscn
+++ b/godot/ScenePlayer.tscn
@@ -57,6 +57,7 @@ tracks/0/keys = {
 [node name="ScenePlayer" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 theme = ExtResource( 6 )
 script = ExtResource( 2 )
 __meta__ = {
@@ -66,6 +67,7 @@ __meta__ = {
 [node name="Background" type="TextureRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 texture = ExtResource( 4 )
 expand = true
 __meta__ = {
@@ -80,6 +82,7 @@ __meta__ = {
 modulate = Color( 1, 1, 1, 0 )
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 color = Color( 0, 0, 0, 1 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/godot/TextBox/BlinkingArrow.tscn
+++ b/godot/TextBox/BlinkingArrow.tscn
@@ -2,7 +2,6 @@
 
 [ext_resource path="res://TextBox/arrow.png" type="Texture" id=1]
 
-
 [sub_resource type="Animation" id=1]
 resource_name = "New Anim"
 length = 0.6
@@ -23,6 +22,7 @@ tracks/0/keys = {
 [node name="Control" type="Control"]
 margin_right = 64.0
 margin_bottom = 48.0
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -35,6 +35,7 @@ anchor_bottom = 1.0
 margin_left = -64.0
 margin_top = -48.0
 margin_right = -24.0
+mouse_filter = 2
 texture = ExtResource( 1 )
 expand = true
 stretch_mode = 5

--- a/godot/TextBox/TextBox.tscn
+++ b/godot/TextBox/TextBox.tscn
@@ -9,8 +9,6 @@
 [ext_resource path="res://TextBox/NameLabel.gd" type="Script" id=7]
 [ext_resource path="res://TextBox/NameBackground.gd" type="Script" id=8]
 
-
-
 [sub_resource type="Animation" id=1]
 resource_name = "fade_in"
 length = 0.5
@@ -198,6 +196,7 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_top = -295.0
+mouse_filter = 2
 theme = ExtResource( 4 )
 texture = ExtResource( 5 )
 script = ExtResource( 1 )
@@ -210,6 +209,7 @@ margin_left = 94.0
 margin_top = -45.1899
 margin_right = 582.0
 margin_bottom = 65.8101
+mouse_filter = 2
 texture = ExtResource( 6 )
 script = ExtResource( 8 )
 __meta__ = {
@@ -246,6 +246,7 @@ margin_left = -689.0
 margin_top = -81.5
 margin_right = 690.0
 margin_bottom = 110.5
+mouse_filter = 2
 bbcode_enabled = true
 bbcode_text = "Text body"
 meta_underlined = false
@@ -264,10 +265,12 @@ margin_left = 17.0
 margin_top = 1.0
 margin_right = 17.0
 margin_bottom = 1.0
+mouse_filter = 1
 
 [node name="ChoiceSelector" parent="." instance=ExtResource( 3 )]
 margin_left = 657.0
 margin_right = -658.0
+mouse_filter = 2
 
 [node name="Tween" type="Tween" parent="."]
 

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -68,6 +68,18 @@ window/stretch/aspect="keep"
 
 enabled=PoolStringArray(  )
 
+[input]
+
+ui_accept={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+
 [rendering]
 
 quality/driver/driver_name="GLES2"


### PR DESCRIPTION
PR for Issue #

To keep using `_unhandled_input` in the TextBox code, we change the mouse filter mode of the UI controls to "Ignore" so any mouse click will go into `_unhandled_input` instead of being consumed by a UI control.

A potential future problem with this is when you add in new UI nodes that block mouse input (mouse filter is "Stop") as they can prevent the mouse click from going into `_unhandled_input` and not being processed. 

An alternative solution, I think, is to replace `_unhandled_input` with `_input`, but I'm not the one making the calls here.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.

**What kind of change does this PR introduce?**
- Change the mouse filter mode of the UI nodes in TextBox.tscn to "Ignore"
- Add detection for the left mouse click (and by extension, touch input too since "Emulate Mouse from Touch" is enabled in the settings) in the Input Map.


**Does this PR introduce a breaking change?**
Probably not.