### PR TITLE
Add button for skipping dialogue

### DIFF
--- a/godot/ScenePlayer.tscn
+++ b/godot/ScenePlayer.tscn
@@ -80,6 +80,7 @@ __meta__ = {
 modulate = Color( 1, 1, 1, 0 )
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 color = Color( 0, 0, 0, 1 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/godot/TextBox/SkipButton.gd
+++ b/godot/TextBox/SkipButton.gd
@@ -1,0 +1,24 @@
+extends Button
+
+## Emitted when the DelayTimer times out.
+signal timer_ticked
+
+onready var _timer := $DelayTimer
+
+
+func _ready() -> void:
+	connect("button_down", self, "_on_button_down")
+	connect("button_up", self, "_on_button_up")
+	_timer.connect("timeout", self, "_on_DelayTimer_timeout")
+
+
+func _on_button_down() -> void:
+	_timer.start()
+
+
+func _on_DelayTimer_timeout() -> void:
+	emit_signal("timer_ticked")
+
+
+func _on_button_up() -> void:
+	_timer.stop()

--- a/godot/TextBox/SkipButton.tscn
+++ b/godot/TextBox/SkipButton.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://TextBox/SkipButton.gd" type="Script" id=1]
+
+[node name="SkipButton" type="Button"]
+self_modulate = Color( 0.678431, 0.678431, 0.678431, 0.67451 )
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -124.0
+margin_top = -76.0
+margin_right = -16.0
+margin_bottom = -16.0
+action_mode = 0
+keep_pressed_outside = true
+text = "SKIP"
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="DelayTimer" type="Timer" parent="."]
+wait_time = 0.1

--- a/godot/TextBox/TextBox.gd
+++ b/godot/TextBox/TextBox.gd
@@ -11,9 +11,7 @@ signal choice_made(target_id)
 export var display_speed := 20.0
 export var bbcode_text := "" setget set_bbcode_text
 
-onready var _controls : HBoxContainer = $Controls
-onready var _skip_button : Button = $Controls/SkipButton
-onready var _skip_button_delay_timer : Timer = $Controls/SkipButton/DelayTimer
+onready var _skip_button : Button = $SkipButton
 
 onready var _name_label: Label = $NameBackground/NameLabel
 onready var _name_background: TextureRect = $NameBackground
@@ -37,9 +35,7 @@ func _ready() -> void:
 	_tween.connect("tween_all_completed", self, "_on_Tween_tween_all_completed")
 	_choice_selector.connect("choice_made", self, "_on_ChoiceSelector_choice_made")
 
-	_skip_button.connect("button_down", self, "_on_SkipButton_button_down")
-	_skip_button.connect("button_up", self, "_on_SkipButton_button_up")
-	_skip_button_delay_timer.connect("timeout", self, "_on_DelayTimer_timeout")
+	_skip_button.connect("timer_ticked", self, "_on_SkipButton_timer_ticked")
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -72,7 +68,7 @@ func display(text: String, character_name := "", speed := display_speed) -> void
 
 
 func display_choice(choices: Array) -> void:
-	_controls.hide()
+	_skip_button.hide()
 	_name_background.disappear()
 	_rich_text_label.hide()
 	_blinking_arrow.hide()
@@ -117,21 +113,10 @@ func _on_Tween_tween_all_completed() -> void:
 
 func _on_ChoiceSelector_choice_made(target_id: int) -> void:
 	emit_signal("choice_made", target_id)
-	_controls.show()
+	_skip_button.show()
 	_name_background.appear()
 	_rich_text_label.show()
 
 
-# Skip dialogue when the button is being held down
-func _on_SkipButton_button_down() -> void:
-	_skip_button_delay_timer.start()
-
-
-# Skip by using a quick loop with the DelayTimer
-func _on_DelayTimer_timeout() -> void:
+func _on_SkipButton_timer_ticked() -> void:
 	advance_dialogue()
-
-
-# Stop skipping the dialogue
-func _on_SkipButton_button_up() -> void:
-	_skip_button_delay_timer.stop()

--- a/godot/TextBox/TextBox.tscn
+++ b/godot/TextBox/TextBox.tscn
@@ -9,8 +9,6 @@
 [ext_resource path="res://TextBox/NameLabel.gd" type="Script" id=7]
 [ext_resource path="res://TextBox/NameBackground.gd" type="Script" id=8]
 
-
-
 [sub_resource type="Animation" id=1]
 resource_name = "fade_in"
 length = 0.5
@@ -87,6 +85,18 @@ tracks/5/keys = {
 "update": 0,
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
+tracks/6/type = "value"
+tracks/6/path = NodePath("Controls:modulate")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/keys = {
+"times": PoolRealArray( 0, 0.132, 0.301612, 0.5 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+}
 
 [sub_resource type="Animation" id=2]
 resource_name = "fade_out"
@@ -124,6 +134,18 @@ tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
 "times": PoolRealArray( 0, 0.133333, 0.266667 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("Controls:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0, 0.132, 0.268054 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
@@ -198,6 +220,7 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_top = -295.0
+mouse_filter = 2
 theme = ExtResource( 4 )
 texture = ExtResource( 5 )
 script = ExtResource( 1 )
@@ -205,11 +228,35 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="Controls" type="HBoxContainer" parent="."]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 500.0
+margin_top = -60.0
+margin_right = -500.0
+mouse_filter = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SkipButton" type="Button" parent="Controls"]
+self_modulate = Color( 0.678431, 0.678431, 0.678431, 0.67451 )
+margin_right = 108.0
+margin_bottom = 60.0
+action_mode = 0
+keep_pressed_outside = true
+text = "SKIP"
+
+[node name="DelayTimer" type="Timer" parent="Controls/SkipButton"]
+wait_time = 0.1
+
 [node name="NameBackground" type="TextureRect" parent="."]
 margin_left = 94.0
 margin_top = -45.1899
 margin_right = 582.0
 margin_bottom = 65.8101
+mouse_filter = 2
 texture = ExtResource( 6 )
 script = ExtResource( 8 )
 __meta__ = {
@@ -246,6 +293,7 @@ margin_left = -689.0
 margin_top = -81.5
 margin_right = 690.0
 margin_bottom = 110.5
+mouse_filter = 2
 bbcode_enabled = true
 bbcode_text = "Text body"
 meta_underlined = false
@@ -264,10 +312,12 @@ margin_left = 17.0
 margin_top = 1.0
 margin_right = 17.0
 margin_bottom = 1.0
+mouse_filter = 1
 
 [node name="ChoiceSelector" parent="." instance=ExtResource( 3 )]
 margin_left = 657.0
 margin_right = -658.0
+mouse_filter = 2
 
 [node name="Tween" type="Tween" parent="."]
 

--- a/godot/TextBox/TextBox.tscn
+++ b/godot/TextBox/TextBox.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://TextBox/TextBox.gd" type="Script" id=1]
 [ext_resource path="res://TextBox/BlinkingArrow.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://TextBox/character-name-box.png" type="Texture" id=6]
 [ext_resource path="res://TextBox/NameLabel.gd" type="Script" id=7]
 [ext_resource path="res://TextBox/NameBackground.gd" type="Script" id=8]
+[ext_resource path="res://TextBox/SkipButton.tscn" type="PackedScene" id=9]
 
 [sub_resource type="Animation" id=1]
 resource_name = "fade_in"
@@ -85,18 +86,6 @@ tracks/5/keys = {
 "update": 0,
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
-tracks/6/type = "value"
-tracks/6/path = NodePath("Controls:modulate")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0, 0.132, 0.301612, 0.5 ),
-"transitions": PoolRealArray( 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
-}
 
 [sub_resource type="Animation" id=2]
 resource_name = "fade_out"
@@ -134,18 +123,6 @@ tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
 "times": PoolRealArray( 0, 0.133333, 0.266667 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("Controls:modulate")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.132, 0.268054 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
@@ -228,28 +205,9 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Controls" type="HBoxContainer" parent="."]
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 500.0
-margin_top = -60.0
-margin_right = -500.0
-mouse_filter = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="SkipButton" type="Button" parent="Controls"]
-self_modulate = Color( 0.678431, 0.678431, 0.678431, 0.67451 )
-margin_right = 108.0
-margin_bottom = 60.0
-action_mode = 0
-keep_pressed_outside = true
-text = "SKIP"
-
-[node name="DelayTimer" type="Timer" parent="Controls/SkipButton"]
-wait_time = 0.1
+[node name="SkipButton" parent="." instance=ExtResource( 9 )]
+margin_left = -140.0
+margin_right = -32.0
 
 [node name="NameBackground" type="TextureRect" parent="."]
 margin_left = 94.0


### PR DESCRIPTION
Add button that when held down will start skipping the dialogue. A quick loop is
used where we advance the dialogue whenever the DelayTimer times out.

A further improvement to this would be to finish any running tweens (character fade ins, screen transitions, animations, etc.) when the skip starts, and instantly finish any tweens that start while the player is still skipping.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #3 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
- Add a SkipButton managed by a HBoxContainer node in the TextBox.tscn
- Wrote the skip functionality in the TextBox code.


**Does this PR introduce a breaking change?**
Probably not.