### PR TITLE
Fix the character animation jittering when the player advance too fast

### DIFF
--- a/godot/Characters/CharacterDisplayer.gd
+++ b/godot/Characters/CharacterDisplayer.gd
@@ -63,8 +63,11 @@ func _enter(from_side: String, sprite: Sprite) -> void:
 	)
 	_tween.interpolate_property(sprite, "modulate", COLOR_WHITE_TRANSPARENT, Color.white, 0.25)
 	_tween.start()
-	# Using Tween.seek() to set the sprite's position and modulate instantly.
-	_tween.seek(0.0)
+
+	# Set up the sprite
+	# We don't use Tween.seek(0.0) here since that could conflict with running tweens and make them jitter back and forth
+	sprite.position = start
+	sprite.modulate = COLOR_WHITE_TRANSPARENT
 
 
 func _leave(from_side: String, sprite: Sprite) -> void:


### PR DESCRIPTION
Whenever a sprite is shown, because it is set up using Tween.seek(0.0), any
other running tweens will get reset, but because we also call Tween.seek(INF)
whenever the player advances, this bug usually isn't noticeable unless the
player advance too fast.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #6 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
- Change the setup code for when a character sprite is displayed.



**Does this PR introduce a breaking change?**
Probably not.